### PR TITLE
{EQEmu PR 3574} [Messages] Remove duplicate message on tracking begin

### DIFF
--- a/zone/client.cpp
+++ b/zone/client.cpp
@@ -10695,8 +10695,6 @@ void Client::SetTrackingID(uint32 entity_id)
 	}
 
 	TrackingID = entity_id;
-
-	MessageString(Chat::Skills, TRACKING_BEGIN, m->GetCleanName());
 }
 
 int Client::GetRecipeMadeCount(uint32 recipe_id)


### PR DESCRIPTION
When you click on a target and hit "tracking", the you begin to track <target> message is coming out twice.

Removing this from the server results in one and only one message on both Titanium and RoF2.