### PR TITLE
{EQEmu PR 4238} [Bug Fix] SPA214 SE_MaxHPChange calculation errors co…

### DIFF
--- a/zone/bonuses.cpp
+++ b/zone/bonuses.cpp
@@ -5007,6 +5007,7 @@ void Mob::NegateSpellEffectBonuses(uint16 spell_id)
 				case SE_MaxHPChange:
 					if (negate_spellbonus) { spellbonuses.MaxHPChange = effect_value; }
 					if (negate_aabonus) { aabonuses.MaxHPChange = effect_value; }
+					if (negate_aabonus) { aabonuses.MaxHP = effect_value; }
 					if (negate_itembonus) { itembonuses.MaxHPChange = effect_value; }
 					break;
 

--- a/zone/bot.cpp
+++ b/zone/bot.cpp
@@ -6454,11 +6454,10 @@ int64 Bot::CalcMaxHP() {
 	uint32 nd = 10000;
 	bot_hp += (GenerateBaseHitPoints() + itembonuses.HP);
 	bot_hp += (GetHeroicSTA() * 10);
-	nd += aabonuses.MaxHP;
+	nd += aabonuses.MaxHP + spellbonuses.MaxHPChange + itembonuses.MaxHPChange;
 	bot_hp = ((float)bot_hp * (float)nd / (float)10000);
 	bot_hp += (spellbonuses.HP + aabonuses.HP);
 	bot_hp += GroupLeadershipAAHealthEnhancement();
-	bot_hp += (bot_hp * ((spellbonuses.MaxHPChange + itembonuses.MaxHPChange) / 10000.0f));
 	max_hp = bot_hp;
 	if (current_hp > max_hp)
 		current_hp = max_hp;

--- a/zone/client_mods.cpp
+++ b/zone/client_mods.cpp
@@ -325,11 +325,13 @@ int64 Client::CalcMaxHP()
 	//but the actual effect sent on live causes the client
 	//to apply it to (basehp + itemhp).. I will oblige to the client's whims over
 	//the aa description
-	nd += aabonuses.MaxHP;	//Natural Durability, Physical Enhancement, Planar Durability
+
+	nd += aabonuses.MaxHP + spellbonuses.MaxHPChange + itembonuses.MaxHPChange;	//Natural Durability, Physical Enhancement, Planar Durability
 	max_hp = (float)max_hp * (float)nd / (float)10000; //this is to fix the HP-above-495k issue
 	max_hp += spellbonuses.HP + aabonuses.HP;
+
 	max_hp += GroupLeadershipAAHealthEnhancement();
-	max_hp += max_hp * ((spellbonuses.MaxHPChange + itembonuses.MaxHPChange) / 10000.0f);
+
 	if (current_hp > max_hp) {
 		current_hp = max_hp;
 	}

--- a/zone/common.h
+++ b/zone/common.h
@@ -336,7 +336,7 @@ struct StatBonuses {
 	int32	AC;
 	int64	HP;
 	int64	HPRegen;
-	int64	MaxHP;
+	int64	MaxHP; //same bonus as MaxHPChange when applied to spells and item bonuses
 	int64	ManaRegen;
 	int64	EnduranceRegen;
 	int64	Mana;
@@ -463,7 +463,7 @@ struct StatBonuses {
 	int32	MeleeLifetap;						//i
 	int32	Vampirism;							//i
 	int32	HealRate;							// Spell effect that influences effectiveness of heals
-	int32	MaxHPChange;						// Spell Effect
+	int32	MaxHPChange;						// percent change in hit points (aabonuses use variable MaxHP)
 	int16	SkillDmgTaken[EQ::skills::HIGHEST_SKILL + 2];		// All Skills + -1
 	int32	HealAmt;							// Item Effect
 	int32	SpellDmg;							// Item Effect

--- a/zone/entity.cpp
+++ b/zone/entity.cpp
@@ -2605,6 +2605,10 @@ void EntityList::RemoveAllMobs()
 {
 	auto it = mob_list.begin();
 	while (it != mob_list.end()) {
+		if (!it->second) {
+			++it;
+			continue;
+		}
 		safe_delete(it->second);
 		free_ids.push(it->first);
 		it = mob_list.erase(it);
@@ -2742,6 +2746,10 @@ bool EntityList::RemoveMob(uint16 delete_id)
 
 	auto it = mob_list.find(delete_id);
 	if (it != mob_list.end()) {
+		if (!it->second) {
+			return false;
+		}
+		
 		if (npc_list.count(delete_id)) {
 			entity_list.RemoveNPC(delete_id);
 		}

--- a/zone/groups.cpp
+++ b/zone/groups.cpp
@@ -778,7 +778,6 @@ bool Group::DelMember(Mob* oldmember, bool ignoresender)
 	return true;
 }
 
-// does the caster + group
 void Group::CastGroupSpell(Mob* caster, uint16 spell_id) {
 	uint32 z;
 	float range, distance;
@@ -792,8 +791,6 @@ void Group::CastGroupSpell(Mob* caster, uint16 spell_id) {
 
 	float range2 = range*range;
 	float min_range2 = spells[spell_id].min_range * spells[spell_id].min_range;
-
-//	caster->SpellOnTarget(spell_id, caster);
 
 	for(z=0; z < MAX_GROUP_MEMBERS; z++)
 	{

--- a/zone/merc.cpp
+++ b/zone/merc.cpp
@@ -460,14 +460,12 @@ int64 Merc::CalcMaxHP() {
 	//but the actual effect sent on live causes the client
 	//to apply it to (basehp + itemhp).. I will oblige to the client's whims over
 	//the aa description
-	nd += aabonuses.MaxHP;  //Natural Durability, Physical Enhancement, Planar Durability
+	nd += aabonuses.MaxHP + spellbonuses.MaxHPChange + itembonuses.MaxHPChange;  //Natural Durability, Physical Enhancement, Planar Durability
 
 	max_hp = (float)max_hp * (float)nd / (float)10000; //this is to fix the HP-above-495k issue
 	max_hp += spellbonuses.HP + aabonuses.HP;
 
 	max_hp += GroupLeadershipAAHealthEnhancement();
-
-	max_hp += max_hp * ((spellbonuses.MaxHPChange + itembonuses.MaxHPChange) / 10000.0f);
 
 	if (current_hp > max_hp)
 		current_hp = max_hp;

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -2571,7 +2571,7 @@ bool Mob::SpellFinished(uint16 spell_id, Mob *spell_target, CastingSlot slot, in
 					Group *target_group = entity_list.GetGroupByMob(spell_target);
 					if(target_group) {
 						target_group->CastGroupSpell(this, spell_id);
-						if (!GetClass() == Class::Bard) {
+						if (target_group != GetGroup() && GetClass() != Class::Bard) {
 							SpellOnTarget(spell_id, this);
 						}
 					}

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -3126,8 +3126,16 @@ int Mob::CheckStackConflict(uint16 spellid1, int caster_level1, uint16 spellid2,
 						sp1.name, spellid1, blocked_effect, blocked_slot, blocked_below_value, sp2_value, (sp2_value < blocked_below_value)?"Blocked":"Not blocked");
 
 					if (sp2_value < blocked_below_value) {
-						LogSpells("Blocking spell because sp2_Value < blocked_below_value");
-						return -1;		//blocked
+						if (IsDetrimentalSpell(spellid2))
+						{
+							//Live fixed this in 2018 to allow detrimental spells to bypass being blocked by SPA 148
+							LogSpells("Detrimental spell [{}] ([{}]) avoids being blocked.", sp2.name, spellid2);
+						}
+						else
+						{
+							LogSpells("Blocking spell because sp2_Value < blocked_below_value");
+							return -1;		//blocked
+						}
 					}
 				} else {
 					LogSpells("[{}] ([{}]) blocks effect [{}] on slot [{}] below [{}], but we do not have that effect on that slot. Ignored",

--- a/zone/spells.cpp
+++ b/zone/spells.cpp
@@ -4577,6 +4577,16 @@ bool Mob::SpellOnTarget(
 	safe_delete(action_packet);
 	safe_delete(message_packet);
 
+	/*
+		Bug: When an HP buff with a heal effect is applied for first time, the heal portion of the effect heals the client and
+		updates HPs correctly server side, but client side the HP bar does not register it as a heal thus you display as less than full HP.
+		However due to server thinking your healed, you are unable to correct it by healing.
+		Solution: You need to resend the HP update after buff completed and action packet resent.
+	*/
+	if ((IsEffectInSpell(spell_id, SE_TotalHP) || IsEffectInSpell(spell_id, SE_MaxHPChange)) && (IsEffectInSpell(spell_id, SE_CurrentHPOnce) || IsEffectInSpell(spell_id, SE_CurrentHP))) {
+		SendHPUpdate(true);
+	}
+
 	LogSpells("Cast of [{}] by [{}] on [{}] complete successfully", spell_id, GetName(), spelltar->GetName());
 
 	return true;


### PR DESCRIPTION
…rrected.

Bug: SPA 214 which changes hit points by percentage was not displaying correctly on the client. This was causing differences between client displayed hit points and server calculations.

Solution: The formula we were using to apply the spell and item bonuses using SPA 214 to client max hit points was incorrect. It should not have been applying it after the AA version (Natural Durability) and after Spell HP buffs (Ie. Virtue). The correct calculation was it should be applied at the same time as the AA version.

Client and server now display the same values within 5 hps of each other.

Fixed for Bots and Mercs as well.